### PR TITLE
Fix singular frame solver

### DIFF
--- a/simulador_viga_mejorado.py
+++ b/simulador_viga_mejorado.py
@@ -1949,7 +1949,10 @@ I_total = Σ(I_barra_i + A_i * d_i²)
         if A.shape[0] != A.shape[1]:
             soluciones, *_ = np.linalg.lstsq(A, b, rcond=None)
         else:
-            soluciones = np.linalg.solve(A, b)
+            try:
+                soluciones = np.linalg.solve(A, b)
+            except np.linalg.LinAlgError:
+                soluciones, *_ = np.linalg.lstsq(A, b, rcond=None)
 
         fuerzas = [soluciones[var_map[f"m{i}"]] for i in range(n_miembros)]
         reacciones = {}


### PR DESCRIPTION
## Summary
- handle singular systems in frame solver by falling back to least-squares

## Testing
- `python3 -m py_compile simulador_viga_mejorado.py`

------
https://chatgpt.com/codex/tasks/task_e_685d6ec37a3c83229f1dbba1e7dec3d3