### PR TITLE
feat: build multilingual marketing landing page

### DIFF
--- a/webapp/static/css/main.css
+++ b/webapp/static/css/main.css
@@ -1,19 +1,23 @@
 :root {
-    --bg-gradient: linear-gradient(120deg, #0f172a 0%, #1e293b 40%, #3b82f6 100%);
-    --color-surface: rgba(15, 23, 42, 0.82);
-    --color-surface-alt: rgba(30, 41, 59, 0.74);
-    --color-border: rgba(148, 163, 184, 0.25);
+    --gradient-start: #0f172a;
+    --gradient-mid: #1f2937;
+    --gradient-end: #2563eb;
+    --color-surface: rgba(15, 23, 42, 0.75);
+    --color-surface-strong: rgba(30, 41, 59, 0.9);
+    --color-border: rgba(148, 163, 184, 0.2);
     --color-primary: #60a5fa;
     --color-primary-strong: #2563eb;
-    --color-accent: #22d3ee;
-    --color-danger: #f97316;
+    --color-secondary: rgba(148, 163, 184, 0.2);
     --color-text: #e2e8f0;
     --color-muted: #94a3b8;
-    --radius-lg: 24px;
-    --radius-md: 16px;
-    --radius-sm: 12px;
-    --shadow-soft: 0 24px 60px rgba(10, 20, 45, 0.45);
+    --color-accent: #22d3ee;
+    --shadow-lg: 0 30px 60px rgba(8, 15, 35, 0.45);
+    --shadow-md: 0 18px 45px rgba(15, 23, 42, 0.4);
+    --radius-lg: 28px;
+    --radius-md: 20px;
+    --radius-sm: 14px;
     --transition: 220ms ease;
+    color-scheme: dark;
 }
 
 * {
@@ -22,549 +26,600 @@
 
 body {
     margin: 0;
-    font-family: 'Poppins', 'Segoe UI', sans-serif;
-    background: #0b1120;
+    font-family: 'Poppins', 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background: radial-gradient(circle at top left, rgba(96, 165, 250, 0.18), transparent 45%),
+        linear-gradient(120deg, var(--gradient-start) 0%, var(--gradient-mid) 50%, var(--gradient-end) 100%);
     color: var(--color-text);
     min-height: 100vh;
+    position: relative;
+    overflow-x: hidden;
 }
 
 .background-gradient {
     position: fixed;
     inset: 0;
-    background: var(--bg-gradient);
+    background: linear-gradient(140deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.6));
+    backdrop-filter: blur(30px) saturate(150%);
+    z-index: -3;
+}
+
+.orb {
+    position: fixed;
+    width: 440px;
+    height: 440px;
+    border-radius: 50%;
+    filter: blur(120px);
+    opacity: 0.75;
     z-index: -2;
 }
 
-body::after {
-    content: '';
-    position: fixed;
-    inset: 0;
-    backdrop-filter: blur(48px) saturate(140%);
-    z-index: -1;
+.orb--one {
+    background: rgba(96, 165, 250, 0.45);
+    top: -120px;
+    left: -160px;
 }
 
-.app-header {
+.orb--two {
+    background: rgba(34, 211, 238, 0.35);
+    bottom: -160px;
+    right: -140px;
+}
+
+.site-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 24px 48px;
+    padding: 28px 64px;
     position: sticky;
     top: 0;
-    background: linear-gradient(120deg, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.78));
-    border-bottom: 1px solid var(--color-border);
     backdrop-filter: blur(24px);
-    z-index: 10;
+    background: linear-gradient(120deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.6));
+    border-bottom: 1px solid var(--color-border);
+    z-index: 20;
+    gap: 24px;
 }
 
 .brand {
     display: flex;
-    gap: 16px;
     align-items: center;
+    gap: 18px;
 }
 
 .brand__logo {
-    width: 52px;
-    height: 52px;
-    border-radius: 20px;
+    width: 58px;
+    height: 58px;
+    border-radius: 22px;
     background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
     display: grid;
     place-items: center;
-    font-weight: 600;
     color: #0f172a;
-    box-shadow: 0 18px 35px rgba(96, 165, 250, 0.25);
+    font-weight: 700;
+    font-size: 1.25rem;
+    box-shadow: 0 20px 35px rgba(96, 165, 250, 0.35);
 }
 
-.brand__title {
+.brand__name {
     margin: 0;
-    font-size: 1.7rem;
-    letter-spacing: 0.02em;
+    font-size: 1.3rem;
+    font-weight: 600;
 }
 
-.brand__subtitle {
-    margin: 2px 0 0;
-    font-size: 0.9rem;
+.brand__tagline {
+    margin: 4px 0 0;
     color: var(--color-muted);
+    font-size: 0.95rem;
 }
 
-.app-nav {
+.site-nav {
     display: flex;
-    gap: 18px;
+    gap: 20px;
 }
 
-.app-nav a {
-    padding: 10px 16px;
-    border-radius: var(--radius-sm);
+.site-nav a {
     color: var(--color-text);
     text-decoration: none;
     font-weight: 500;
-    background: rgba(148, 163, 184, 0.12);
-    border: 1px solid transparent;
-    transition: transform var(--transition), background var(--transition), border var(--transition);
-}
-
-.app-nav a:hover,
-.app-nav a:focus {
-    background: rgba(96, 165, 250, 0.18);
-    border-color: rgba(96, 165, 250, 0.4);
-    transform: translateY(-2px);
-}
-
-.app-shell {
-    display: grid;
-    gap: 32px;
-    grid-template-columns: minmax(320px, 380px) 1fr;
-    padding: 32px 48px 64px;
-}
-
-.sidebar {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-    position: sticky;
-    top: 120px;
-    max-height: calc(100vh - 140px);
-    overflow-y: auto;
-    padding-right: 12px;
-}
-
-.sidebar__section {
-    background: var(--color-surface);
-    border-radius: var(--radius-lg);
-    border: 1px solid rgba(96, 165, 250, 0.12);
-    box-shadow: var(--shadow-soft);
-    padding: 22px 24px;
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-}
-
-.sidebar__header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 12px;
-}
-
-.project-summary {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 18px;
-    margin: 0;
-}
-
-.project-summary div {
-    background: var(--color-surface-alt);
-    padding: 16px;
-    border-radius: var(--radius-md);
-    border: 1px solid rgba(148, 163, 184, 0.15);
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-
-.project-summary dt {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    color: var(--color-muted);
-    letter-spacing: 0.08em;
-}
-
-.project-summary dd {
-    margin: 0;
-    font-weight: 600;
-    font-size: 1.05rem;
-}
-
-.templates {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.template-card {
-    background: var(--color-surface-alt);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    border: 1px solid rgba(96, 165, 250, 0.12);
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    transition: transform var(--transition), border var(--transition);
-}
-
-.template-card:hover {
-    transform: translateY(-3px);
-    border-color: rgba(96, 165, 250, 0.35);
-}
-
-.template-card__title {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
-}
-
-.template-card__description {
-    margin: 0;
-    color: var(--color-muted);
-    font-size: 0.85rem;
-}
-
-.workspace {
-    background: var(--color-surface);
-    border-radius: var(--radius-lg);
-    border: 1px solid rgba(96, 165, 250, 0.12);
-    box-shadow: var(--shadow-soft);
-    padding: 32px;
-}
-
-.workspace__form {
-    display: flex;
-    flex-direction: column;
-    gap: 32px;
-}
-
-.stepper {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 12px;
-}
-
-.stepper__step {
-    background: rgba(96, 165, 250, 0.12);
-    border: 1px solid transparent;
-    border-radius: var(--radius-sm);
-    padding: 12px;
-    color: var(--color-text);
-    font-weight: 500;
-    cursor: pointer;
-    transition: background var(--transition), transform var(--transition), border var(--transition);
-}
-
-.stepper__step:hover,
-.stepper__step:focus {
-    background: rgba(96, 165, 250, 0.22);
-    transform: translateY(-2px);
-}
-
-.stepper__step--active {
-    background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
-    color: #0f172a;
-}
-
-.step {
-    display: none;
-    flex-direction: column;
-    gap: 24px;
-}
-
-.step--active {
-    display: flex;
-}
-
-.step h2 {
-    margin: 0;
-    font-size: 1.3rem;
-}
-
-.form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 24px;
-}
-
-.field {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
-
-.field label {
-    font-size: 0.85rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--color-muted);
-}
-
-.field input,
-.field select {
-    padding: 12px 14px;
-    border-radius: var(--radius-sm);
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    background: rgba(15, 23, 42, 0.65);
-    color: var(--color-text);
-    font-size: 0.95rem;
-    transition: border var(--transition), box-shadow var(--transition);
-}
-
-.field input:focus,
-.field select:focus {
-    border-color: rgba(96, 165, 250, 0.4);
-    box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.18);
-    outline: none;
-}
-
-#support_c_position_group {
-    display: none;
-}
-
-.loads-layout {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 24px;
-}
-
-.dynamic-list {
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
-}
-
-.dynamic-item {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 12px;
-    padding: 16px;
-    border-radius: var(--radius-md);
-    background: rgba(15, 23, 42, 0.65);
-    border: 1px solid rgba(96, 165, 250, 0.12);
-    position: relative;
-}
-
-.dynamic-item__remove {
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: none;
-    background: rgba(248, 113, 113, 0.18);
-    color: #fee2e2;
-    font-size: 1.1rem;
-    cursor: pointer;
-    transition: transform var(--transition), background var(--transition);
-}
-
-.dynamic-item__remove:hover {
-    transform: scale(1.05);
-    background: rgba(248, 113, 113, 0.28);
-}
-
-.btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: var(--radius-sm);
     padding: 10px 16px;
-    font-weight: 600;
+    border-radius: var(--radius-sm);
+    background: transparent;
     border: 1px solid transparent;
-    cursor: pointer;
-    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+    transition: var(--transition);
 }
 
-.btn--primary {
-    background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
-    color: #0f172a;
-    box-shadow: 0 16px 30px rgba(96, 165, 250, 0.35);
+.site-nav a:hover,
+.site-nav a:focus {
+    background: rgba(96, 165, 250, 0.12);
+    border-color: rgba(96, 165, 250, 0.45);
+    transform: translateY(-1px);
 }
 
-.btn--primary:hover {
-    transform: translateY(-2px);
-}
-
-.btn--ghost {
-    background: rgba(148, 163, 184, 0.14);
-    color: var(--color-text);
-    border: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.btn--ghost:hover {
-    transform: translateY(-2px);
-    border-color: rgba(96, 165, 250, 0.35);
-}
-
-.actions {
+.header-actions {
     display: flex;
-    gap: 12px;
     align-items: center;
-}
-
-.feedback {
-    font-size: 0.85rem;
-    color: var(--color-muted);
-}
-
-.feedback--error {
-    color: #fca5a5;
-}
-
-.results-grid {
-    display: grid;
-    gap: 24px;
-}
-
-.panel__section {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-    background: var(--color-surface-alt);
-    border-radius: var(--radius-md);
-    padding: 20px;
-    border: 1px solid rgba(148, 163, 184, 0.12);
-}
-
-.panel__title {
-    margin: 0;
-    font-size: 1.1rem;
-    font-weight: 600;
-}
-
-.cards-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 16px;
 }
 
-.card {
-    background: rgba(15, 23, 42, 0.68);
-    border-radius: var(--radius-md);
-    padding: 18px;
-    border: 1px solid rgba(96, 165, 250, 0.14);
+.language-switcher {
+    display: inline-flex;
+    padding: 4px;
+    border-radius: var(--radius-sm);
+    background: rgba(148, 163, 184, 0.12);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.language-switcher__btn {
+    font-family: inherit;
+    font-size: 0.85rem;
+    padding: 6px 14px;
+    border: none;
+    background: transparent;
+    color: var(--color-text);
+    border-radius: 10px;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.language-switcher__btn.is-active,
+.language-switcher__btn:hover {
+    background: rgba(96, 165, 250, 0.25);
+    color: #0f172a;
+}
+
+.primary-button,
+.secondary-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 22px;
+    border-radius: var(--radius-sm);
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition: var(--transition);
+    cursor: pointer;
+}
+
+.primary-button {
+    background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+    color: #0b1120;
+    box-shadow: 0 18px 36px rgba(37, 99, 235, 0.35);
+}
+
+.primary-button:hover,
+.primary-button:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 40px rgba(37, 99, 235, 0.45);
+}
+
+.secondary-button {
+    background: rgba(148, 163, 184, 0.18);
+    border-color: rgba(148, 163, 184, 0.25);
+    color: var(--color-text);
+}
+
+.secondary-button:hover,
+.secondary-button:focus {
+    border-color: rgba(148, 163, 184, 0.4);
+    background: rgba(148, 163, 184, 0.28);
+}
+
+main {
+    padding: 48px 64px 96px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 80px;
 }
 
-.card__value {
-    font-size: 1.25rem;
-    margin: 0;
-}
-
-.card__meta {
-    margin: 0;
-    color: var(--color-muted);
-    font-size: 0.85rem;
-}
-
-.equilibrium {
+.section {
+    max-width: 1180px;
+    margin: 0 auto;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 36px;
+}
+
+.section--surface {
+    padding: 48px;
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    box-shadow: var(--shadow-lg);
+}
+
+.section__header {
+    display: grid;
     gap: 12px;
 }
 
-.equilibrium div {
-    background: rgba(15, 23, 42, 0.6);
-    padding: 14px;
-    border-radius: var(--radius-sm);
-    border: 1px solid rgba(96, 165, 250, 0.12);
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
+.section__header h2 {
+    margin: 0;
+    font-size: clamp(1.6rem, 2.5vw, 2.1rem);
+    font-weight: 600;
 }
 
-.equilibrium span {
-    color: var(--color-muted);
-    font-size: 0.85rem;
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.75rem;
+    color: var(--color-accent);
+    font-weight: 600;
 }
 
-.equilibrium strong {
-    font-size: 1.05rem;
-}
-
-.charts-grid {
+.hero {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+    align-items: center;
+    gap: 48px;
+}
+
+.hero__title {
+    margin: 0;
+    font-size: clamp(2.2rem, 4vw, 3.1rem);
+    font-weight: 700;
+}
+
+.hero__lead {
+    margin: 12px 0 0;
+    color: var(--color-muted);
+    font-size: 1.05rem;
+    max-width: 540px;
+}
+
+.hero__benefits {
+    margin: 24px 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 10px;
+}
+
+.hero__benefits li {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: rgba(148, 163, 184, 0.12);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.hero__actions {
+    display: flex;
+    gap: 14px;
+    margin-top: 28px;
+}
+
+.hero__footnote {
+    margin: 18px 0 0;
+    color: var(--color-muted);
+    font-size: 0.9rem;
+    max-width: 520px;
+}
+
+.hero__visual {
+    display: grid;
+    place-items: center;
+}
+
+.hero-card {
+    width: 100%;
+    padding: 28px;
+    border-radius: var(--radius-lg);
+    background: var(--color-surface-strong);
+    border: 1px solid var(--color-border);
+    box-shadow: var(--shadow-lg);
+    display: grid;
     gap: 18px;
 }
 
-.chart-card {
-    background: rgba(15, 23, 42, 0.65);
-    border-radius: var(--radius-md);
-    padding: 18px;
-    border: 1px solid rgba(96, 165, 250, 0.12);
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.loads-table {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.load-row {
+.hero-card header {
     display: flex;
     justify-content: space-between;
-    gap: 12px;
-    background: rgba(15, 23, 42, 0.65);
-    padding: 12px 16px;
-    border-radius: var(--radius-sm);
-    border: 1px solid rgba(96, 165, 250, 0.1);
+    align-items: baseline;
+}
+
+.hero-card__label {
+    color: var(--color-muted);
     font-size: 0.95rem;
 }
 
-.empty-state {
+.hero-card__value {
+    font-size: 2.4rem;
+    font-weight: 700;
+}
+
+.hero-card__divider {
+    height: 1px;
+    background: rgba(148, 163, 184, 0.2);
+}
+
+.hero-card__status {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+}
+
+.hero-card__status span {
+    color: var(--color-muted);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.hero-card__status strong {
+    display: block;
+    margin-top: 4px;
+    font-size: 1.8rem;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 22px;
+}
+
+.feature-card {
+    padding: 26px;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    background: rgba(15, 23, 42, 0.7);
+    box-shadow: var(--shadow-md);
+    display: grid;
+    gap: 14px;
+}
+
+.feature-card h3 {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.feature-card p {
     margin: 0;
     color: var(--color-muted);
-    font-size: 0.9rem;
 }
 
-.insights {
+.timeline {
     list-style: none;
-    padding: 0;
     margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+    padding: 0;
+    display: grid;
+    gap: 26px;
 }
 
-.insights li {
-    background: rgba(15, 23, 42, 0.65);
-    border-radius: var(--radius-md);
-    border: 1px solid rgba(96, 165, 250, 0.12);
-    padding: 12px 14px;
-    font-size: 0.9rem;
-    display: flex;
-    gap: 10px;
+.timeline__item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 18px;
     align-items: flex-start;
 }
 
-.app-footer {
-    padding: 32px;
-    text-align: center;
+.timeline__index {
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, rgba(96, 165, 250, 0.2), rgba(34, 211, 238, 0.25));
+    border: 1px solid rgba(96, 165, 250, 0.4);
+    font-weight: 600;
+}
+
+.timeline h3 {
+    margin: 0 0 6px;
+    font-size: 1.2rem;
+}
+
+.timeline p {
+    margin: 0;
     color: var(--color-muted);
+    max-width: 620px;
+}
+
+.access-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 24px;
+}
+
+.access-card {
+    padding: 28px;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.72);
+    box-shadow: var(--shadow-md);
+    display: grid;
+    gap: 18px;
+}
+
+.access-card--highlight {
+    background: linear-gradient(135deg, rgba(96, 165, 250, 0.18), rgba(37, 99, 235, 0.28));
+    border-color: rgba(96, 165, 250, 0.45);
+}
+
+.access-card__note {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 0.9rem;
+}
+
+.form {
+    display: grid;
+    gap: 12px;
+}
+
+.form label {
+    font-weight: 500;
+}
+
+.form input {
+    width: 100%;
+    padding: 12px 14px;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.6);
+    color: var(--color-text);
+    font-size: 0.95rem;
+    transition: var(--transition);
+}
+
+.form input:focus {
+    outline: none;
+    border-color: rgba(96, 165, 250, 0.6);
+    box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.15);
+}
+
+.form__link {
+    color: var(--color-primary);
+    text-decoration: none;
+    font-size: 0.9rem;
+}
+
+.form__link:hover {
+    text-decoration: underline;
+}
+
+.form__status {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 14px;
+    border-radius: 12px;
+    background: rgba(96, 165, 250, 0.14);
+    border: 1px solid rgba(96, 165, 250, 0.32);
+}
+
+.form__status strong {
+    font-size: 1rem;
+    color: var(--color-text);
+}
+
+.admin-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 22px;
+}
+
+.status-card {
+    padding: 26px;
+    border-radius: var(--radius-md);
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: var(--shadow-md);
+    display: grid;
+    gap: 10px;
+    text-align: center;
+}
+
+.status-card h3 {
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+.status-card strong {
+    font-size: 2rem;
+}
+
+.status-card p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.admin-tip {
+    margin: 12px 0 0;
+    color: var(--color-muted);
+    font-size: 0.95rem;
+    text-align: center;
+}
+
+.site-footer {
+    padding: 48px 64px 64px;
+    text-align: center;
+    display: grid;
+    gap: 10px;
+    color: var(--color-muted);
+}
+
+.site-footer p {
+    margin: 0;
+}
+
+.site-footer__legal {
     font-size: 0.85rem;
 }
 
 @media (max-width: 1200px) {
-    .app-shell {
+    .hero {
         grid-template-columns: 1fr;
     }
 
-    .sidebar {
-        position: static;
-        max-height: none;
-        padding-right: 0;
+    .hero__visual {
+        order: -1;
+    }
+
+    .feature-grid,
+    .access-grid,
+    .admin-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 
-@media (max-width: 768px) {
-    .app-header {
-        flex-direction: column;
-        gap: 16px;
-    }
-
-    .app-nav {
+@media (max-width: 960px) {
+    .site-header {
         flex-wrap: wrap;
+        padding: 20px 32px;
+        gap: 18px;
+    }
+
+    .site-nav {
+        order: 3;
+        width: 100%;
         justify-content: center;
+        flex-wrap: wrap;
+        gap: 12px;
     }
 
-    .workspace {
+    main {
+        padding: 40px 32px 80px;
+        gap: 64px;
+    }
+
+    .section--surface {
+        padding: 32px;
+    }
+}
+
+@media (max-width: 720px) {
+    .feature-grid,
+    .access-grid,
+    .admin-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .language-switcher {
+        order: -1;
+    }
+
+    .header-actions {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .hero__actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}
+
+@media (max-width: 520px) {
+    .site-header {
+        padding: 18px;
+    }
+
+    main {
+        padding: 32px 18px 64px;
+    }
+
+    .section--surface {
         padding: 24px;
-    }
-
-    .stepper {
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     }
 }

--- a/webapp/static/js/landing.js
+++ b/webapp/static/js/landing.js
@@ -1,0 +1,219 @@
+const translations = {
+    es: {
+        'brand-title': 'Mecánica Estructural Pro',
+        'brand-subtitle': 'Simulador web para ingeniería moderna',
+        'nav-overview': 'Visión general',
+        'nav-features': 'Capacidades',
+        'nav-workflow': 'Flujo de acceso',
+        'nav-access': 'Ingreso',
+        'nav-admin': 'Panel admin',
+        'header-cta': 'Entrar al software',
+        'hero-subtitle': 'Simulaciones avanzadas desde cualquier dispositivo.',
+        'hero-title': 'Analiza estructuras con precisión de clase profesional',
+        'hero-description': 'Combina cálculo automatizado, reportes dinámicos y una gestión clara de usuarios para tu organización.',
+        'hero-bullet-1': 'Modelos de vigas con cargas puntuales y distribuidas.',
+        'hero-bullet-2': 'Resultados visuales listos para reportes ejecutivos.',
+        'hero-bullet-3': 'Gestión de accesos con aprobación centralizada.',
+        'hero-cta-primary': 'Acceso al simulador',
+        'hero-cta-secondary': 'Conoce más',
+        'hero-footnote': 'Los administradores también ingresan desde el portal de usuarios para mantener un único punto de acceso.',
+        'stat-1-label': 'Proyectos analizados',
+        'stat-1-value': '1200+',
+        'stat-1-caption': 'Resultados auditados y listos para ingeniería.',
+        'stat-2-label': 'Tiempos de cálculo',
+        'stat-2-value': '< 10 s',
+        'stat-2-caption': 'Promedio en escenarios complejos.',
+        'stat-3-label': 'Satisfacción',
+        'stat-3-value': '98%',
+        'stat-3-caption': 'Equipos que confían en la plataforma.',
+        'features-title': 'Diseñado para equipos exigentes',
+        'features-description': 'Cada módulo fue creado para brindar confianza y velocidad en tus entregables técnicos.',
+        'feature-1-title': 'Motor de cálculo robusto',
+        'feature-1-description': 'Utiliza algoritmos validados para reacciones, diagramas de cortante, momento flector y torsor.',
+        'feature-2-title': 'Reportes claros',
+        'feature-2-description': 'Descarga resultados en formatos ejecutivos y comparte escenarios preconfigurados.',
+        'feature-3-title': 'Experiencia impecable',
+        'feature-3-description': 'Interfaz adaptativa, accesible y lista para ambientes corporativos.',
+        'workflow-title': 'Proceso de incorporación sencillo',
+        'workflow-description': 'Desde la solicitud hasta el acceso total en minutos.',
+        'workflow-step-1-title': 'Registro de usuario',
+        'workflow-step-1-description': 'Completa el formulario con un correo válido para identificar la cuenta.',
+        'workflow-step-2-title': 'Estado: Esperando aprobación',
+        'workflow-step-2-description': 'El solicitante puede revisar el portal y ver el estado hasta que un administrador lo apruebe.',
+        'workflow-step-3-title': 'Aprobación del administrador',
+        'workflow-step-3-description': 'El panel central muestra usuarios en línea, aprobados y rechazados para controlar accesos.',
+        'workflow-step-4-title': 'Ingreso al software',
+        'workflow-step-4-description': 'Una vez aprobado, el usuario y los administradores utilizan el mismo inicio de sesión.',
+        'access-title': 'Punto de acceso unificado',
+        'access-description': 'Mantén toda la operación controlada desde un único portal.',
+        'software-card-title': 'Acceso al software',
+        'software-card-description': 'Ingresa directamente al simulador con tu usuario aprobado.',
+        'software-card-button': 'Iniciar simulador',
+        'software-card-note': 'Disponible únicamente para cuentas aprobadas por un administrador.',
+        'login-card-title': 'Inicio de sesión',
+        'login-card-description': 'Acceso para usuarios aprobados y administradores.',
+        'login-email-label': 'Correo electrónico',
+        'login-email-placeholder': 'nombre@empresa.com',
+        'login-password-label': 'Contraseña',
+        'login-password-placeholder': '********',
+        'login-submit': 'Iniciar sesión',
+        'login-forgot': '¿Olvidaste tu contraseña?',
+        'register-card-title': 'Crear cuenta',
+        'register-card-description': 'Solicita acceso y sigue el estado de aprobación.',
+        'register-name-label': 'Nombre completo',
+        'register-name-placeholder': 'Ingresa tu nombre',
+        'register-email-label': 'Correo corporativo',
+        'register-email-placeholder': 'usuario@empresa.com',
+        'register-role-label': 'Rol esperado',
+        'register-role-placeholder': 'Ej. Ingeniero estructural',
+        'register-status-label': 'Estado actual',
+        'register-status-value': 'Esperando aprobación',
+        'register-submit': 'Enviar solicitud',
+        'register-help': 'Puedes registrar un correo inicial y actualizarlo luego desde la configuración administrativa.',
+        'admin-title': 'Panel administrativo claro',
+        'admin-description': 'Monitorea aprobaciones y actividad en tiempo real.',
+        'admin-card-online': 'Usuarios en línea',
+        'admin-card-online-detail': 'Actividad concurrente monitoreada al instante.',
+        'admin-card-approved': 'Aprobados',
+        'admin-card-approved-detail': 'Controla quién tiene acceso operativo.',
+        'admin-card-rejected': 'Rechazados',
+        'admin-card-rejected-detail': 'Historial transparente para auditorías.',
+        'admin-tip': 'Todos los administradores y usuarios utilizan el mismo inicio de sesión. Los administradores pueden actualizar correos desde la configuración del panel.',
+        'footer-cta': '¿Listo para potenciar tus análisis estructurales?',
+    },
+    en: {
+        'brand-title': 'Structural Mechanics Pro',
+        'brand-subtitle': 'Web simulator for modern engineering',
+        'nav-overview': 'Overview',
+        'nav-features': 'Capabilities',
+        'nav-workflow': 'Access flow',
+        'nav-access': 'Entry',
+        'nav-admin': 'Admin panel',
+        'header-cta': 'Enter the software',
+        'hero-subtitle': 'Advanced simulations on any device.',
+        'hero-title': 'Analyze structures with professional-grade accuracy',
+        'hero-description': 'Combine automated calculations, dynamic reports, and transparent user management for your organisation.',
+        'hero-bullet-1': 'Beam models with point and distributed loads.',
+        'hero-bullet-2': 'Visual results ready for executive reporting.',
+        'hero-bullet-3': 'Access management with centralized approval.',
+        'hero-cta-primary': 'Simulator access',
+        'hero-cta-secondary': 'Learn more',
+        'hero-footnote': 'Administrators also sign in through the user portal to maintain a single entry point.',
+        'stat-1-label': 'Projects evaluated',
+        'stat-1-value': '1200+',
+        'stat-1-caption': 'Audited results ready for engineering teams.',
+        'stat-2-label': 'Computation time',
+        'stat-2-value': '< 10 s',
+        'stat-2-caption': 'Average under complex scenarios.',
+        'stat-3-label': 'Satisfaction',
+        'stat-3-value': '98%',
+        'stat-3-caption': 'Teams that rely on the platform.',
+        'features-title': 'Built for demanding teams',
+        'features-description': 'Every module was crafted to deliver confidence and speed in your technical deliverables.',
+        'feature-1-title': 'Robust calculation engine',
+        'feature-1-description': 'Employs validated algorithms for reactions, shear, bending moment, and torsor diagrams.',
+        'feature-2-title': 'Clear reporting',
+        'feature-2-description': 'Download executive-grade outputs and share curated scenarios.',
+        'feature-3-title': 'Polished experience',
+        'feature-3-description': 'Adaptive, accessible interface ready for corporate environments.',
+        'workflow-title': 'Onboarding made simple',
+        'workflow-description': 'From request to full access in minutes.',
+        'workflow-step-1-title': 'User registration',
+        'workflow-step-1-description': 'Complete the form with a valid email to identify the account.',
+        'workflow-step-2-title': 'Status: Awaiting approval',
+        'workflow-step-2-description': 'Applicants can monitor the portal and see the status until an administrator approves them.',
+        'workflow-step-3-title': 'Administrator approval',
+        'workflow-step-3-description': 'The central panel highlights online, approved, and rejected users for precise control.',
+        'workflow-step-4-title': 'Software access',
+        'workflow-step-4-description': 'Once approved, users and administrators leverage the same login experience.',
+        'access-title': 'Unified access point',
+        'access-description': 'Keep your entire operation controlled from a single portal.',
+        'software-card-title': 'Software access',
+        'software-card-description': 'Enter the simulator directly with your approved account.',
+        'software-card-button': 'Launch simulator',
+        'software-card-note': 'Available only for accounts approved by an administrator.',
+        'login-card-title': 'Sign in',
+        'login-card-description': 'Access for approved users and administrators.',
+        'login-email-label': 'Email address',
+        'login-email-placeholder': 'name@company.com',
+        'login-password-label': 'Password',
+        'login-password-placeholder': '********',
+        'login-submit': 'Log in',
+        'login-forgot': 'Forgot your password?',
+        'register-card-title': 'Create account',
+        'register-card-description': 'Request access and monitor the approval status.',
+        'register-name-label': 'Full name',
+        'register-name-placeholder': 'Enter your name',
+        'register-email-label': 'Corporate email',
+        'register-email-placeholder': 'user@company.com',
+        'register-role-label': 'Expected role',
+        'register-role-placeholder': 'e.g. Structural engineer',
+        'register-status-label': 'Current status',
+        'register-status-value': 'Awaiting approval',
+        'register-submit': 'Submit request',
+        'register-help': 'You can provide an initial email and update it later within the admin settings.',
+        'admin-title': 'Clear administrative panel',
+        'admin-description': 'Monitor approvals and activity in real time.',
+        'admin-card-online': 'Users online',
+        'admin-card-online-detail': 'Concurrent activity tracked instantly.',
+        'admin-card-approved': 'Approved',
+        'admin-card-approved-detail': 'Keep tight control on who has operational access.',
+        'admin-card-rejected': 'Rejected',
+        'admin-card-rejected-detail': 'Transparent history for audits.',
+        'admin-tip': 'Administrators and users share the same login. Admins can update emails from the panel settings.',
+        'footer-cta': 'Ready to elevate your structural analyses?',
+    },
+};
+
+const STORAGE_KEY = 'mechanics.landing.language';
+const DEFAULT_LANG = 'es';
+
+function applyLanguage(lang) {
+    const dictionary = translations[lang] ?? translations[DEFAULT_LANG];
+
+    document.documentElement.lang = lang;
+
+    document.querySelectorAll('[data-l10n]').forEach((element) => {
+        const key = element.dataset.l10n;
+        const value = dictionary[key];
+        if (typeof value !== 'undefined') {
+            element.innerHTML = value;
+        }
+    });
+
+    document.querySelectorAll('[data-l10n-placeholder]').forEach((element) => {
+        const key = element.dataset.l10nPlaceholder;
+        const value = dictionary[key];
+        if (typeof value !== 'undefined') {
+            element.setAttribute('placeholder', value);
+        }
+    });
+
+    document.querySelectorAll('[data-lang]').forEach((button) => {
+        button.classList.toggle('is-active', button.dataset.lang === lang);
+    });
+}
+
+function initLanguageToggle() {
+    const storedLang = window.localStorage?.getItem(STORAGE_KEY);
+    const initialLang = Object.prototype.hasOwnProperty.call(translations, storedLang) ? storedLang : DEFAULT_LANG;
+
+    applyLanguage(initialLang);
+
+    document.querySelectorAll('[data-lang]').forEach((button) => {
+        button.addEventListener('click', () => {
+            const lang = button.dataset.lang;
+            if (!Object.prototype.hasOwnProperty.call(translations, lang)) {
+                return;
+            }
+            window.localStorage?.setItem(STORAGE_KEY, lang);
+            applyLanguage(lang);
+        });
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initLanguageToggle);
+} else {
+    initLanguageToggle();
+}

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -3,273 +3,226 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Simulador de Estructuras Web</title>
+    <title>Mecánica Estructural Pro</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="/static/css/main.css" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/main.css') }}" />
 </head>
 <body>
     <div class="background-gradient"></div>
-    <header class="app-header">
+    <div class="orb orb--one"></div>
+    <div class="orb orb--two"></div>
+
+    <header class="site-header">
         <div class="brand">
             <span class="brand__logo">ME</span>
             <div>
-                <h1 class="brand__title">Simulador de Estructuras</h1>
-                <p class="brand__subtitle">Suite profesional para análisis de vigas</p>
+                <p class="brand__name" data-l10n="brand-title">Mecánica Estructural Pro</p>
+                <p class="brand__tagline" data-l10n="brand-subtitle">Simulador web para ingeniería moderna</p>
             </div>
         </div>
-        <nav class="app-nav">
-            <a href="#panel-config">Configuración</a>
-            <a href="#panel-cargas">Cargas</a>
-            <a href="#panel-resultados">Resultados</a>
-            <a href="#panel-reportes">Reportes</a>
+        <nav class="site-nav" aria-label="Principal">
+            <a href="#overview" data-l10n="nav-overview">Visión general</a>
+            <a href="#features" data-l10n="nav-features">Capacidades</a>
+            <a href="#workflow" data-l10n="nav-workflow">Flujo de acceso</a>
+            <a href="#access" data-l10n="nav-access">Ingreso</a>
+            <a href="#admin" data-l10n="nav-admin">Panel admin</a>
         </nav>
+        <div class="header-actions">
+            <div class="language-switcher" role="group" aria-label="Selector de idioma">
+                <button type="button" class="language-switcher__btn" data-lang="es">ES</button>
+                <button type="button" class="language-switcher__btn" data-lang="en">EN</button>
+            </div>
+            <a class="primary-button" href="#access" data-l10n="header-cta">Entrar al software</a>
+        </div>
     </header>
 
-    <main class="app-shell">
-        <aside class="sidebar" aria-label="Panel de control global">
-            <section class="sidebar__section">
-                <header class="sidebar__header">
-                    <h2>Resumen del proyecto</h2>
-                    <button type="button" class="btn btn--ghost" id="export-json">Exportar JSON</button>
-                </header>
-                <dl class="project-summary" id="project-summary">
+    <main>
+        <section id="overview" class="hero section">
+            <div class="hero__content">
+                <span class="eyebrow" data-l10n="hero-subtitle">Simulaciones avanzadas desde cualquier dispositivo.</span>
+                <h1 class="hero__title" data-l10n="hero-title">Analiza estructuras con precisión de clase profesional</h1>
+                <p class="hero__lead" data-l10n="hero-description">
+                    Combina cálculo automatizado, reportes dinámicos y una gestión clara de usuarios para tu organización.
+                </p>
+                <ul class="hero__benefits">
+                    <li data-l10n="hero-bullet-1">Modelos de vigas con cargas puntuales y distribuidas.</li>
+                    <li data-l10n="hero-bullet-2">Resultados visuales listos para reportes ejecutivos.</li>
+                    <li data-l10n="hero-bullet-3">Gestión de accesos con aprobación centralizada.</li>
+                </ul>
+                <div class="hero__actions">
+                    <a class="primary-button" href="#access" data-l10n="hero-cta-primary">Acceso al simulador</a>
+                    <a class="secondary-button" href="#features" data-l10n="hero-cta-secondary">Conoce más</a>
+                </div>
+                <p class="hero__footnote" data-l10n="hero-footnote">
+                    Los administradores también ingresan desde el portal de usuarios para mantener un único punto de acceso.
+                </p>
+            </div>
+            <div class="hero__visual" aria-hidden="true">
+                <div class="hero-card">
+                    <header>
+                        <span class="hero-card__label" data-l10n="stat-1-label">Proyectos analizados</span>
+                        <strong class="hero-card__value" data-l10n="stat-1-value">1200+</strong>
+                    </header>
+                    <p data-l10n="stat-1-caption">Resultados auditados y listos para ingeniería.</p>
+                    <div class="hero-card__divider"></div>
+                    <div class="hero-card__status">
+                        <div>
+                            <span data-l10n="stat-2-label">Tiempos de cálculo</span>
+                            <strong data-l10n="stat-2-value">&lt; 10 s</strong>
+                            <p data-l10n="stat-2-caption">Promedio en escenarios complejos.</p>
+                        </div>
+                        <div>
+                            <span data-l10n="stat-3-label">Satisfacción</span>
+                            <strong data-l10n="stat-3-value">98%</strong>
+                            <p data-l10n="stat-3-caption">Equipos que confían en la plataforma.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="features" class="section">
+            <header class="section__header">
+                <span class="eyebrow" data-l10n="features-title">Diseñado para equipos exigentes</span>
+                <h2 data-l10n="features-description">Cada módulo fue creado para brindar confianza y velocidad en tus entregables técnicos.</h2>
+            </header>
+            <div class="feature-grid">
+                <article class="feature-card">
+                    <h3 data-l10n="feature-1-title">Motor de cálculo robusto</h3>
+                    <p data-l10n="feature-1-description">
+                        Utiliza algoritmos validados para reacciones, diagramas de cortante, momento flector y torsor.
+                    </p>
+                </article>
+                <article class="feature-card">
+                    <h3 data-l10n="feature-2-title">Reportes claros</h3>
+                    <p data-l10n="feature-2-description">
+                        Descarga resultados en formatos ejecutivos y comparte escenarios preconfigurados.
+                    </p>
+                </article>
+                <article class="feature-card">
+                    <h3 data-l10n="feature-3-title">Experiencia impecable</h3>
+                    <p data-l10n="feature-3-description">
+                        Interfaz adaptativa, accesible y lista para ambientes corporativos.
+                    </p>
+                </article>
+            </div>
+        </section>
+
+        <section id="workflow" class="section section--surface">
+            <header class="section__header">
+                <span class="eyebrow" data-l10n="workflow-title">Proceso de incorporación sencillo</span>
+                <h2 data-l10n="workflow-description">Desde la solicitud hasta el acceso total en minutos.</h2>
+            </header>
+            <ol class="timeline">
+                <li class="timeline__item">
+                    <div class="timeline__index">1</div>
                     <div>
-                        <dt>Longitud</dt>
-                        <dd data-summary="length">0.00 m</dd>
+                        <h3 data-l10n="workflow-step-1-title">Registro de usuario</h3>
+                        <p data-l10n="workflow-step-1-description">Completa el formulario con un correo válido para identificar la cuenta.</p>
                     </div>
+                </li>
+                <li class="timeline__item">
+                    <div class="timeline__index">2</div>
                     <div>
-                        <dt>Apoyos</dt>
-                        <dd data-summary="supports">—</dd>
+                        <h3 data-l10n="workflow-step-2-title">Estado: Esperando aprobación</h3>
+                        <p data-l10n="workflow-step-2-description">El solicitante puede revisar el portal y ver el estado hasta que un administrador lo apruebe.</p>
                     </div>
+                </li>
+                <li class="timeline__item">
+                    <div class="timeline__index">3</div>
                     <div>
-                        <dt>Cargas puntuales</dt>
-                        <dd data-summary="point-loads">0</dd>
+                        <h3 data-l10n="workflow-step-3-title">Aprobación del administrador</h3>
+                        <p data-l10n="workflow-step-3-description">El panel central muestra usuarios en línea, aprobados y rechazados para controlar accesos.</p>
                     </div>
+                </li>
+                <li class="timeline__item">
+                    <div class="timeline__index">4</div>
                     <div>
-                        <dt>Cargas distribuidas</dt>
-                        <dd data-summary="distributed-loads">0</dd>
+                        <h3 data-l10n="workflow-step-4-title">Ingreso al software</h3>
+                        <p data-l10n="workflow-step-4-description">Una vez aprobado, el usuario y los administradores utilizan el mismo inicio de sesión.</p>
                     </div>
-                    <div>
-                        <dt>Centro de masa</dt>
-                        <dd data-summary="center-of-mass">—</dd>
-                    </div>
-                    <div>
-                        <dt>Último cálculo</dt>
-                        <dd data-summary="last-run">—</dd>
-                    </div>
-                </dl>
-            </section>
+                </li>
+            </ol>
+        </section>
 
-            <section class="sidebar__section" id="template-browser">
-                <header class="sidebar__header">
-                    <h2>Escenarios</h2>
-                    <button type="button" class="btn btn--ghost" id="reload-templates">Actualizar</button>
-                </header>
-                <div class="templates" id="template-list" aria-live="polite"></div>
-            </section>
+        <section id="access" class="section">
+            <header class="section__header">
+                <span class="eyebrow" data-l10n="access-title">Punto de acceso unificado</span>
+                <h2 data-l10n="access-description">Mantén toda la operación controlada desde un único portal.</h2>
+            </header>
+            <div class="access-grid">
+                <article class="access-card access-card--highlight">
+                    <h3 data-l10n="software-card-title">Acceso al software</h3>
+                    <p data-l10n="software-card-description">Ingresa directamente al simulador con tu usuario aprobado.</p>
+                    <a class="primary-button" href="#" data-l10n="software-card-button">Iniciar simulador</a>
+                    <p class="access-card__note" data-l10n="software-card-note">Disponible únicamente para cuentas aprobadas por un administrador.</p>
+                </article>
+                <article class="access-card">
+                    <h3 data-l10n="login-card-title">Inicio de sesión</h3>
+                    <p data-l10n="login-card-description">Acceso para usuarios aprobados y administradores.</p>
+                    <form class="form">
+                        <label data-l10n="login-email-label" for="login-email">Correo electrónico</label>
+                        <input id="login-email" type="email" data-l10n-placeholder="login-email-placeholder" placeholder="nombre@empresa.com" />
+                        <label data-l10n="login-password-label" for="login-password">Contraseña</label>
+                        <input id="login-password" type="password" data-l10n-placeholder="login-password-placeholder" placeholder="********" />
+                        <button type="submit" class="primary-button" data-l10n="login-submit">Iniciar sesión</button>
+                        <a class="form__link" href="#" data-l10n="login-forgot">¿Olvidaste tu contraseña?</a>
+                    </form>
+                </article>
+                <article class="access-card">
+                    <h3 data-l10n="register-card-title">Crear cuenta</h3>
+                    <p data-l10n="register-card-description">Solicita acceso y sigue el estado de aprobación.</p>
+                    <form class="form">
+                        <label data-l10n="register-name-label" for="register-name">Nombre completo</label>
+                        <input id="register-name" type="text" data-l10n-placeholder="register-name-placeholder" placeholder="Ingresa tu nombre" />
+                        <label data-l10n="register-email-label" for="register-email">Correo corporativo</label>
+                        <input id="register-email" type="email" data-l10n-placeholder="register-email-placeholder" placeholder="usuario@empresa.com" />
+                        <label data-l10n="register-role-label" for="register-role">Rol esperado</label>
+                        <input id="register-role" type="text" data-l10n-placeholder="register-role-placeholder" placeholder="Ej. Ingeniero estructural" />
+                        <div class="form__status">
+                            <span data-l10n="register-status-label">Estado actual</span>
+                            <strong data-l10n="register-status-value">Esperando aprobación</strong>
+                        </div>
+                        <button type="submit" class="secondary-button" data-l10n="register-submit">Enviar solicitud</button>
+                    </form>
+                    <p class="access-card__note" data-l10n="register-help">Puedes registrar un correo inicial y actualizarlo luego desde la configuración administrativa.</p>
+                </article>
+            </div>
+        </section>
 
-            <section class="sidebar__section" id="insights">
-                <h2>Insights del análisis</h2>
-                <ul id="analysis-insights" class="insights"></ul>
-            </section>
-        </aside>
-
-        <section class="workspace">
-            <form id="beam-form" class="workspace__form" autocomplete="off">
-                <nav class="stepper" id="form-stepper">
-                    <button type="button" data-step="geometria" class="stepper__step stepper__step--active">1. Geometría</button>
-                    <button type="button" data-step="apoyos" class="stepper__step">2. Apoyos</button>
-                    <button type="button" data-step="cargas" class="stepper__step">3. Cargas</button>
-                    <button type="button" data-step="opciones" class="stepper__step">4. Opciones</button>
-                    <button type="button" data-step="resultados" class="stepper__step">5. Resultados</button>
-                </nav>
-
-                <section class="step" data-step-panel="geometria" id="panel-config">
-                    <h2>Parámetros globales</h2>
-                    <div class="form-grid">
-                        <div class="field">
-                            <label for="length">Longitud de la viga (m)</label>
-                            <input id="length" name="length" type="number" step="0.1" min="0" required />
-                        </div>
-                        <div class="field">
-                            <label for="height_start">Altura inicio (m)</label>
-                            <input id="height_start" name="height_start" type="number" step="0.01" />
-                        </div>
-                        <div class="field">
-                            <label for="height_end">Altura fin (m)</label>
-                            <input id="height_end" name="height_end" type="number" step="0.01" />
-                        </div>
-                        <div class="field">
-                            <label for="torsor">Par torsor externo (N·m)</label>
-                            <input id="torsor" name="torsor" type="number" step="0.1" value="0" />
-                        </div>
-                    </div>
-                </section>
-
-                <section class="step" data-step-panel="apoyos">
-                    <h2>Configuración de apoyos</h2>
-                    <div class="form-grid">
-                        <div class="field">
-                            <label for="support_a_type">Apoyo A</label>
-                            <select id="support_a_type" name="support_a_type">
-                                <option value="Fijo">Fijo</option>
-                                <option value="Movil">Móvil</option>
-                                <option value="Ninguno">Ninguno</option>
-                            </select>
-                        </div>
-                        <div class="field">
-                            <label for="support_b_type">Apoyo B</label>
-                            <select id="support_b_type" name="support_b_type">
-                                <option value="Fijo">Fijo</option>
-                                <option value="Movil" selected>Móvil</option>
-                                <option value="Ninguno">Ninguno</option>
-                            </select>
-                        </div>
-                        <div class="field">
-                            <label for="support_c_type">Apoyo C (opcional)</label>
-                            <select id="support_c_type" name="support_c_type">
-                                <option value="Ninguno">Ninguno</option>
-                                <option value="Fijo">Fijo</option>
-                                <option value="Movil">Móvil</option>
-                            </select>
-                        </div>
-                        <div class="field" id="support_c_position_group">
-                            <label for="support_c_position">Posición apoyo C (m)</label>
-                            <input id="support_c_position" name="support_c_position" type="number" step="0.1" min="0" />
-                        </div>
-                    </div>
-                </section>
-
-                <section class="step" data-step-panel="cargas" id="panel-cargas">
-                    <h2>Gestión de cargas</h2>
-                    <div class="loads-layout">
-                        <article>
-                            <header class="panel__title">Cargas puntuales</header>
-                            <div id="point-loads" class="dynamic-list" aria-live="polite"></div>
-                            <button type="button" class="btn btn--ghost" id="add-point-load">Agregar carga puntual</button>
-                        </article>
-                        <article>
-                            <header class="panel__title">Cargas distribuidas</header>
-                            <div id="distributed-loads" class="dynamic-list" aria-live="polite"></div>
-                            <button type="button" class="btn btn--ghost" id="add-distributed-load">Agregar carga distribuida</button>
-                        </article>
-                    </div>
-                </section>
-
-                <section class="step" data-step-panel="opciones">
-                    <h2>Opciones de análisis</h2>
-                    <div class="form-grid">
-                        <div class="field">
-                            <label for="num_points">Resolución de diagramas</label>
-                            <input id="num_points" name="num_points" type="number" min="100" max="5000" step="50" value="800" />
-                        </div>
-                        <div class="field">
-                            <label for="unit_system">Sistema de unidades</label>
-                            <select id="unit_system" name="unit_system">
-                                <option value="SI">Internacional (SI)</option>
-                                <option value="US">Imperial (US)</option>
-                            </select>
-                        </div>
-                        <div class="field">
-                            <label for="export_format">Formato de exportación</label>
-                            <select id="export_format" name="export_format">
-                                <option value="json">JSON</option>
-                                <option value="csv">CSV</option>
-                                <option value="xlsx">Excel</option>
-                            </select>
-                        </div>
-                        <div class="field">
-                            <label for="auto-analyze">Análisis automático</label>
-                            <input id="auto-analyze" name="auto-analyze" type="checkbox" checked />
-                        </div>
-                    </div>
-                </section>
-
-                <section class="step" data-step-panel="resultados" id="panel-resultados">
-                    <h2>Resultados</h2>
-                    <div class="actions">
-                        <button type="submit" class="btn btn--primary">Calcular</button>
-                        <button type="button" class="btn btn--ghost" id="reset-form">Restablecer</button>
-                        <span id="form-feedback" class="feedback" role="status"></span>
-                    </div>
-
-                    <div class="results-grid">
-                        <section class="panel__section">
-                            <h3 class="panel__title">Resumen de reacciones</h3>
-                            <div class="cards-grid" id="reactions-summary">
-                                <article class="card" data-reaction="A">
-                                    <h4>Apoyo A</h4>
-                                    <p class="card__value" data-field="vertical">0.00 N</p>
-                                    <p class="card__meta" data-field="horizontal">Horizontal: 0.00 N</p>
-                                </article>
-                                <article class="card" data-reaction="B">
-                                    <h4>Apoyo B</h4>
-                                    <p class="card__value" data-field="vertical">0.00 N</p>
-                                    <p class="card__meta" data-field="horizontal">Horizontal: 0.00 N</p>
-                                </article>
-                                <article class="card" data-reaction="C">
-                                    <h4>Apoyo C</h4>
-                                    <p class="card__value" data-field="vertical">0.00 N</p>
-                                    <p class="card__meta" data-field="horizontal">Horizontal: 0.00 N</p>
-                                </article>
-                            </div>
-                            <div class="equilibrium" id="equilibrium-summary">
-                                <div>
-                                    <span>SF<sub>y</sub></span>
-                                    <strong data-field="sum_vertical_loads">0.00 N</strong>
-                                </div>
-                                <div>
-                                    <span>SM<sub>A</sub></span>
-                                    <strong data-field="sum_moment_about_a">0.00 N·m</strong>
-                                </div>
-                                <div>
-                                    <span>Par externo</span>
-                                    <strong data-field="torsor">0.00 N·m</strong>
-                                </div>
-                                <div>
-                                    <span>Centro de masa</span>
-                                    <strong id="center-of-mass">—</strong>
-                                </div>
-                            </div>
-                        </section>
-
-                        <section class="panel__section" id="panel-reportes">
-                            <h3 class="panel__title">Detalle de cargas</h3>
-                            <div class="loads-table" id="loads-detail"></div>
-                        </section>
-
-                        <section class="panel__section">
-                            <h3 class="panel__title">Diagramas</h3>
-                            <div class="charts-grid">
-                                <figure class="chart-card">
-                                    <figcaption>Fuerza cortante</figcaption>
-                                    <canvas id="shearChart" height="220"></canvas>
-                                </figure>
-                                <figure class="chart-card">
-                                    <figcaption>Momento flector</figcaption>
-                                    <canvas id="momentChart" height="220"></canvas>
-                                </figure>
-                                <figure class="chart-card">
-                                    <figcaption>Par torsor</figcaption>
-                                    <canvas id="torsorChart" height="220"></canvas>
-                                </figure>
-                            </div>
-                        </section>
-                    </div>
-                </section>
-            </form>
+        <section id="admin" class="section section--surface">
+            <header class="section__header">
+                <span class="eyebrow" data-l10n="admin-title">Panel administrativo claro</span>
+                <h2 data-l10n="admin-description">Monitorea aprobaciones y actividad en tiempo real.</h2>
+            </header>
+            <div class="admin-grid">
+                <article class="status-card">
+                    <h3 data-l10n="admin-card-online">Usuarios en línea</h3>
+                    <strong>08</strong>
+                    <p data-l10n="admin-card-online-detail">Actividad concurrente monitoreada al instante.</p>
+                </article>
+                <article class="status-card">
+                    <h3 data-l10n="admin-card-approved">Aprobados</h3>
+                    <strong>152</strong>
+                    <p data-l10n="admin-card-approved-detail">Controla quién tiene acceso operativo.</p>
+                </article>
+                <article class="status-card">
+                    <h3 data-l10n="admin-card-rejected">Rechazados</h3>
+                    <strong>05</strong>
+                    <p data-l10n="admin-card-rejected-detail">Historial transparente para auditorías.</p>
+                </article>
+            </div>
+            <p class="admin-tip" data-l10n="admin-tip">Todos los administradores y usuarios utilizan el mismo inicio de sesión. Los administradores pueden actualizar correos desde la configuración del panel.</p>
         </section>
     </main>
 
-    <footer class="app-footer">
-        <p>© {{ current_year }} Simulador de Estructuras. Plataforma integral para análisis estructural.</p>
-        <p>FastAPI · Chart.js · Diseño personalizado.</p>
+    <footer class="site-footer">
+        <p data-l10n="footer-cta">¿Listo para potenciar tus análisis estructurales?</p>
+        <p class="site-footer__legal">© {{ current_year }} Mecánica Estructural Pro. Todos los derechos reservados.</p>
     </footer>
 
-    <script>window.__DEFAULT_PAYLOAD__ = {{ default_payload | tojson | safe }};</script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" integrity="sha384-e7NmBGG99nmHn7+O+kO5OVwOB1p5MNDoAuCEi0aKBslZx2drXr/7EQo1gChX2NDN" crossorigin="anonymous"></script>
-    <script src="/static/js/app.js" type="module"></script>
+    <script src="{{ url_for('static', path='js/landing.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the default dashboard template with a marketing-oriented landing page that highlights simulator capabilities, access flows and admin controls in two languages
- rebuild the shared stylesheet with a glassmorphism-inspired layout, responsive grids and refined typography for the new sections
- add a lightweight JavaScript translator that toggles Spanish and English copy while persisting the preferred language

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d369d69c848331b4e0476ea56ad635